### PR TITLE
録音ページ作成

### DIFF
--- a/assets/config/_var.scss
+++ b/assets/config/_var.scss
@@ -33,6 +33,7 @@ $required-text: #b60000;
 $required-border: #b60000;
 
 $background-black: #111;
+$background-gray: $button-gray;
 $black-background-text: #eee;
 $black-background-link-color: #{$color-brand}bb;
 $background-hidden-color: #f6f7fa;

--- a/components/Atoms/Icons/IconMicrophone.vue
+++ b/components/Atoms/Icons/IconMicrophone.vue
@@ -1,0 +1,15 @@
+<template>
+  <div class="icon_microphone__components">
+    <img
+      class="icon--microphone"
+      src="~/static/icon/microphone-of-voice.svg" 
+      alt="icon-microphone"
+    >
+  </div>
+</template>
+
+<style scoped lang="scss">
+.icon--microphone {
+  width: 10rem;
+}
+</style>

--- a/components/Atoms/RecordButton.vue
+++ b/components/Atoms/RecordButton.vue
@@ -1,0 +1,67 @@
+<template>
+  <div 
+    class="record__button__wrapper"
+    @click="handleButtonClick"
+  >
+    <div class="record__button--outside">
+      <div class="record__button--inside">
+        <icon-microphone class="icon_microphone" />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import IconMicrophone from '~/components/Atoms/Icons/IconMicrophone'
+
+export default {
+  components: {
+    IconMicrophone,
+  },
+  methods: {
+    handleButtonClick() {
+      this.$emit('buttonClick')
+    }
+  }
+}
+</script>
+
+<style scoped lang="scss">
+.record__button__wrapper {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.record__button {
+  &--outside {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 10rem;
+    height: 10rem;
+    border-radius: 50%;
+    background-color: $color-white;
+  }
+
+  &--inside {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 5rem;
+    height: 5rem;
+    background-color: $color-yellow;
+    border-radius: 50%;
+  }
+}
+
+.icon_microphone {
+  padding-top: 0.5rem;
+
+  /deep/ .icon--microphone {
+    width: 3rem;
+  }
+}
+
+</style>

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -28,6 +28,10 @@ export default {
       { 
         rel: 'stylesheet', 
         href: 'https://fonts.googleapis.com/css?family=Vibur&display=swap' 
+      },
+      { 
+        rel: 'stylesheet', 
+        href: 'href="https://fonts.googleapis.com/css?family=Unica+One&display=swap"' 
       }
     ]
   },

--- a/pages/posts/new.vue
+++ b/pages/posts/new.vue
@@ -1,0 +1,15 @@
+<template>
+  <div>
+    new
+  </div>
+</template>
+
+<script>
+export default {
+  
+}
+</script>
+
+<style lang="scss">
+  
+</style>

--- a/pages/record.vue
+++ b/pages/record.vue
@@ -1,0 +1,42 @@
+<template>
+  <div class="record__container">
+    <div class="record__timer">
+      01:30
+    </div>
+    <record-button @buttonClick="handleRecord" />
+  </div>
+</template>
+
+<script>
+import RecordButton from '~/components/Atoms/RecordButton'
+
+export default {
+  components: {
+    RecordButton
+  },
+  methods: {
+    handleRecord() {
+      console.log('録音ボタン')
+    }
+  }
+}
+</script>
+
+<style scoped lang="scss">
+.record__container {
+  width: 100%;
+  height: 100vh;
+  display: flex;
+  text-align: center;
+  flex-direction: column;
+  align-content: center;
+  justify-content: center;
+  background-color: $background-gray;
+}
+
+.record__timer {
+  font-family: 'Unica One';
+  font-size: 3.5rem;
+  color: $color-white;
+}
+</style>

--- a/static/icon/microphone-of-voice.svg
+++ b/static/icon/microphone-of-voice.svg
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<svg 
+	xmlns="http://www.w3.org/2000/svg" 
+	xmlns:xlink="http://www.w3.org/1999/xlink" 
+	version="1.1" 
+	id="Capa_1" 
+	x="0px" 
+	y="0px" 
+	width="512px" 
+	height="512px" 
+	viewBox="0 0 484.5 484.5" 
+	style="enable-background:new 0 0 484.5 484.5;" 
+	xml:space="preserve" class=""
+>
+	<g>
+		<g>
+			<g id="mic">
+				<path 
+					d="M242.25,306c43.35,0,76.5-33.15,76.5-76.5v-153c0-43.35-33.15-76.5-76.5-76.5c-43.35,0-76.5,33.15-76.5,76.5v153    C165.75,272.85,198.9,306,242.25,306z M377.4,229.5c0,76.5-63.75,130.05-135.15,130.05c-71.4,0-135.15-53.55-135.15-130.05H63.75    c0,86.7,68.85,158.1,153,170.85v84.15h51v-84.15c84.15-12.75,153-84.149,153-170.85H377.4L377.4,229.5z" 
+					data-original="#000000" 
+					class="active-path" 
+					data-old_color="#000000" 
+					fill="#FAFAF8"
+				/>
+			</g>
+		</g>
+	</g> 
+</svg>


### PR DESCRIPTION
refs #44 

- record ページを作成
- マイクの svg アイコンを追加
- マイクボタンのコンポーネントを作成
  - 録音処理はページで行う想定

![image](https://user-images.githubusercontent.com/13540113/62834370-0bbbb000-bc86-11e9-9516-d26df649e548.png)
