### PR TITLE
drawerメニューの表示・非表示の設定

### DIFF
--- a/components/Organisms/AppAsideMenu.vue
+++ b/components/Organisms/AppAsideMenu.vue
@@ -16,12 +16,14 @@
       </div>
     </div>
 
-    <div class="app_aside_menu__items">
+    <div 
+      class="app_aside_menu__items"
+    >
       <div
         v-for="(menuItem, index) in menuList"
         :key="index"
         class="app_aside_menu__item"
-        @click="$router.push(menuItem.path)"
+        @click="handleClick(menuItem)"
       >
         <div>
           <component 
@@ -50,6 +52,7 @@ import IconCategory from '~/components/Atoms/Icons/IconCategory'
 import IconTag from '~/components/Atoms/Icons/IconTag'
 
 export default {
+  name: 'AppAsideMenu',
   components: {
     IconNewsFeed,
     IconSearch,
@@ -118,6 +121,10 @@ export default {
   methods: {
       getComponent(menuItem) {
         return 'icon-' + menuItem.icon
+      },
+      handleClick(menuItem) {
+        this.$emit('click')
+        this.$router.push(menuItem.path)
       }
     }
 }

--- a/components/Organisms/AppAsideMenu.vue
+++ b/components/Organisms/AppAsideMenu.vue
@@ -126,21 +126,13 @@ export default {
 <style lang="scss" scoped>
 @import '~/assets/background.scss';
 
-$slide-size: 25rem;
-
 .app_aside_menu {
-  width: $slide-size;
+  width: 100%;
   transition: transform 0.3s;
   position: fixed;
   top: 4rem;
   z-index: 2;
   transition: all 300ms 200ms ease;
-}
-
-.drawer-wrap {
-  position: fixed;
-  top: 8rem;
-  z-index: 2;
 }
 
 .drawer-layout.dorowa {

--- a/layouts/user.vue
+++ b/layouts/user.vue
@@ -13,19 +13,19 @@
     </div>
     <!-- ⬇プラグイン -->
     <vue-drawer-layout
+      class="vue_drawer_layout"
       ref="drawerLayout"
       :z-index="10"
       :backdrop="true"
-      @mask-click="handleMaskClick"
       :drawer-width="250"
       :content-drawable="true"
-      class="vue_drawer_layout"
+      @mask-click="handleMaskClick"
     >
       <div
         slot="drawer"
         class="drawer-content"
       >
-        <app-aside-menu />
+        <app-aside-menu @click="hideDrawerMenu"/>
       </div>
       <div
         slot="content"
@@ -63,6 +63,9 @@ export default {
     },
     handleMaskClick() {
       this.$refs.drawerLayout.toggle(false)
+    },
+    hideDrawerMenu() {
+      this.$refs.drawerLayout.toggle()
     }
   }
 }

--- a/layouts/user.vue
+++ b/layouts/user.vue
@@ -15,7 +15,10 @@
     <vue-drawer-layout
       ref="drawerLayout"
       :z-index="10"
-      :backdrop="false"
+      :backdrop="true"
+      @mask-click="handleMaskClick"
+      :drawer-width="250"
+      :content-drawable="true"
       class="vue_drawer_layout"
     >
       <div
@@ -57,6 +60,9 @@ export default {
   methods: {
     handleToggleDrawer() {
       this.$refs.drawerLayout.toggle()
+    },
+    handleMaskClick() {
+      this.$refs.drawerLayout.toggle(false)
     }
   }
 }


### PR DESCRIPTION
refs #84 

- drawerメニューにマスクの追加

- マスククリックでdrawerメニューが非表示

- drawerメニュー表示中はメインコンテンツがスライド表示

- drawerメニューの項目クリックでページ遷移する時にメニューを非表示に設定
![drawer5](https://user-images.githubusercontent.com/43144816/65776729-a7917480-e17d-11e9-83ad-be0cc9bda286.gif)
