### PR TITLE
投稿データを Firebase にアップロードする

### DIFF
--- a/components/Atoms/AppButton.vue
+++ b/components/Atoms/AppButton.vue
@@ -34,7 +34,7 @@ export default {
       type: String,
       default: 'white',
       validator(val) {
-        return ['white', 'gray', 'yellow', 'transparent'].includes(val)
+        return ['white', 'gray', 'pink', 'transparent'].includes(val)
       }
     },
     disabled: {

--- a/pages/posts/new.vue
+++ b/pages/posts/new.vue
@@ -71,7 +71,6 @@ import AppButton from '~/components/Atoms/AppButton'
 import EditorJS from '@editorjs/editorjs'
 import { mapState } from 'vuex'
 import firebase from '~/plugins/firebase'
-import { error } from 'util'
 
 const db = firebase.firestore()
 const thumbnailStorageRef = firebase.storage().ref('thumbnails')
@@ -80,6 +79,11 @@ export default {
   components: {
     AppButton
   },
+  middleware({ store, redirect }) {
+    if (!store.state.post.postData.audioUrl) {
+      return redirect('/recording')
+    }
+  },
   data:() => ({
     editor: null,
     postData: {
@@ -87,7 +91,7 @@ export default {
       thumbnail_photo_url: '',
       article: '',
     },
-    thumbnailImage: null, // ここで使うサムネイルのイメージ
+    thumbnailImageUrl: null, // ここで使うサムネイルのイメージURL
     rawImageFile: null, // アップロードする イメージファイル
   }),
   computed: {
@@ -97,7 +101,7 @@ export default {
       auth: store => store.auth.user
     }),
     getThumbnailImage() {
-      return `background-image: url(${this.thumbnailImage})`
+      return `background-image: url(${this.thumbnailImageUrl})`
     }
   },
   created() {
@@ -112,7 +116,7 @@ export default {
       // アップロード用のファイルデータ
       this.rawImageFile = imageFile
       // 投稿ページ用のサムネイル画像URL
-      this.thumbnailImage = imageUrl
+      this.thumbnailImageUrl = imageUrl
     },
     async uploadThumbnailImage(data) {
       const thumbnailRef = thumbnailStorageRef.child(this.postId)
@@ -155,8 +159,8 @@ export default {
       }
 
       db.collection('posts').doc(this.postId).set(requestPostData)
-      .then(doc => {
-        console.log(`post data added`)
+      .then(() => {
+        console.log(`success!! post ID: ${this.postId}`)
       })
       .catch(e => {
         console.error(e)

--- a/pages/posts/new.vue
+++ b/pages/posts/new.vue
@@ -1,16 +1,22 @@
 <template>
   <div class="new__container">
     <div class="new">
-      <main class="title__container">
+      <main
+        class="title__container"
+        :style="getThumbnailImage"
+      >
         <textarea
+          v-model="postData.title"
           class="title"
           placeholder="タイトルを入力"
         />
         <input
           id="ref-image"
           type="file"
+          ref="file"
           multiple
           accept="image/jpeg, image/png"
+          @change="inputImage"
         >
         <label
           for="ref-image"
@@ -52,7 +58,7 @@
         <app-button
           class="app_button post_button"
           text="POST"
-          color="yellow"
+          color="pink"
           @click="uploadPost"
         />
       </div>
@@ -64,41 +70,106 @@
 import AppButton from '~/components/Atoms/AppButton'
 import EditorJS from '@editorjs/editorjs'
 import { mapState } from 'vuex'
+import firebase from '~/plugins/firebase'
+import { error } from 'util'
+
+const db = firebase.firestore()
+const thumbnailStorageRef = firebase.storage().ref('thumbnails')
 
 export default {
   components: {
     AppButton
   },
   data:() => ({
-    editor: null
+    editor: null,
+    postData: {
+      title: '',
+      thumbnail_photo_url: '',
+      article: '',
+    },
+    thumbnailImage: null, // ここで使うサムネイルのイメージ
+    rawImageFile: null, // アップロードする イメージファイル
   }),
   computed: {
     ...mapState({
-      audioUrl: store => store.post.audioUrl
-    })
+      postId: store => store.post.postData.id,
+      audioUrl: store => store.post.postData.audioUrl,
+      auth: store => store.auth.user
+    }),
+    getThumbnailImage() {
+      return `background-image: url(${this.thumbnailImage})`
+    }
   },
   created() {
     this.editor = new EditorJS({ 
       holder: 'editor',
-      data: {
-        "blocks":[{"type":"paragraph","data":{"text":"無添加のシャボン玉石けんならもう安心！！"}},{"type":"paragraph","data":{"text":"天然の保湿成分が含まれるため、肌に潤いを与え、健やかに保ちます。"}},{"type":"paragraph","data":{"text":"お肌のことでお悩みの方は、ぜひ一度無添加シャボン玉石けんをお試しください。"}},{"type":"paragraph","data":{"text":"お求めは<b>0120-0055-95</b>まで。"}}]
-      }
+      // data: {
+      //   "blocks":[{"type":"paragraph","data":{"text":"無添加のシャボン玉石けんならもう安心！！"}},{"type":"paragraph","data":{"text":"天然の保湿成分が含まれるため、肌に潤いを与え、健やかに保ちます。"}},{"type":"paragraph","data":{"text":"お肌のことでお悩みの方は、ぜひ一度無添加シャボン玉石けんをお試しください。"}},{"type":"paragraph","data":{"text":"お求めは<b>0120-0055-95</b>まで。"}}]
+      // }
     })
   },
   methods: {
-    uploadPost() {
-      this.editor.save().then(data => {
-        console.log(data)
-        const rawPostData = JSON.stringify(data)
-        console.log(rawPostData)
-        // rawPostData を firebase にアップする
-        this.$router.push('/news_feed')
-      }).catch(error => {
-        console.log(error)
+    inputImage() {
+      const imageFile = this.$refs.file.files[0]
+      const imageUrl = window.URL.createObjectURL(imageFile)
+      // アップロード用のファイルデータ
+      this.rawImageFile = imageFile
+      // 投稿ページ用のサムネイル画像URL
+      this.thumbnailImage = imageUrl
+    },
+    async uploadThumbnailImage(data) {
+      const thumbnailRef = thumbnailStorageRef.child(this.postId)
+      await thumbnailRef.put(data).then(snapshot => {
+        console.log(`upload success!!: ${snapshot.state}`)
+      })
+      await thumbnailRef.getDownloadURL().then(url => {
+        this.postData.thumbnail_photo_url = url
       })
     },
+    async getArticleData() {
+      await this.editor.save().then(data => {
+        this.postData.article = JSON.stringify(data)
+      })
+    },
+    async uploadPost() {
+      if (!this.rawImageFile) {
+        console.log('Nothing Image File')
+        return
+      }
+      // 1, サムネイル画像をアップロードする
+      await this.uploadThumbnailImage(this.rawImageFile)
+
+      // 2, Editor.js のデータを取得
+      await this.getArticleData()
+      
+      // 3, ポストデータを Firebase にアップする
+      const requestPostData = {
+        id: this.postId,
+        author: {
+          uid: this.auth.uid,
+          name: this.auth.displayName,
+          icon_url: this.auth.photoURL
+        },
+        title: this.postData.title,
+        thumbnail_photo_url: this.postData.thumbnail_photo_url,
+        audio_url: this.audioUrl,
+        article: this.postData.article,
+        posted_at: firebase.firestore.FieldValue.serverTimestamp()
+      }
+
+      db.collection('posts').doc(this.postId).set(requestPostData)
+      .then(doc => {
+        console.log(`post data added`)
+      })
+      .catch(e => {
+        console.error(e)
+      })
+      
+      // 4, マイポストページにリダイレクトする
+        // this.$router.push('/my-page')
+    },
     handleClick() {
-      console.log('Clicked!!')
+      console.log('clicked!!')
     }
   }
 }
@@ -133,6 +204,7 @@ export default {
   display: flex;
   flex-direction: column;
   background-color: $button-gray;
+  background-size: cover;
   padding-top: 5rem;
   margin-bottom: 2rem;
 }

--- a/pages/posts/new.vue
+++ b/pages/posts/new.vue
@@ -25,7 +25,7 @@
             class="audio"
             controls
             preload="auto"
-            src="http://www.voice-pro.jp/announce/mp3/001-sibutomo.mp3"
+            :src="audioUrl"
           >
             <code>audio</code> element
           </audio>
@@ -63,6 +63,7 @@
 <script>
 import AppButton from '~/components/Atoms/AppButton'
 import EditorJS from '@editorjs/editorjs'
+import { mapState } from 'vuex'
 
 export default {
   components: {
@@ -71,6 +72,11 @@ export default {
   data:() => ({
     editor: null
   }),
+  computed: {
+    ...mapState({
+      audioUrl: store => store.post.audioUrl
+    })
+  },
   created() {
     this.editor = new EditorJS({ 
       holder: 'editor',

--- a/pages/posts/new.vue
+++ b/pages/posts/new.vue
@@ -102,10 +102,7 @@ export default {
   },
   created() {
     this.editor = new EditorJS({ 
-      holder: 'editor',
-      // data: {
-      //   "blocks":[{"type":"paragraph","data":{"text":"無添加のシャボン玉石けんならもう安心！！"}},{"type":"paragraph","data":{"text":"天然の保湿成分が含まれるため、肌に潤いを与え、健やかに保ちます。"}},{"type":"paragraph","data":{"text":"お肌のことでお悩みの方は、ぜひ一度無添加シャボン玉石けんをお試しください。"}},{"type":"paragraph","data":{"text":"お求めは<b>0120-0055-95</b>まで。"}}]
-      // }
+      holder: 'editor'
     })
   },
   methods: {

--- a/pages/recording.vue
+++ b/pages/recording.vue
@@ -10,12 +10,6 @@
       :is-active="isActiveRecord"
       @buttonClick="handleRecord"
     />
-
-    <audio
-      v-if="previewAudioData"
-      :src="previewAudioData"
-      controls
-    />
   </div>
 </template>
 
@@ -25,7 +19,7 @@ import RecordButton from '~/components/Atoms/RecordButton'
 import record from '~/utils/record'
 import { mapActions } from 'vuex'
 
-const storageRef = firebase.storage().ref()
+const audioStorageRef = firebase.storage().ref('audio')
 
 export default {
   head: () => ({
@@ -47,13 +41,12 @@ export default {
     isActiveRecord: false,
     rawAudioData: null,
     previewAudioData: null,
-    downloadAudioUrl: null,
     timerId: null,
     min: 0,
     sec: 0
   }),
   methods: {
-    ...mapActions('post', ['addAudioUrl']),
+    ...mapActions('post', ['addPostId', 'addAudioUrl']),
     async handleRecord() {
       // 録音状態だったら
       if (this.isActiveRecord) {
@@ -100,15 +93,16 @@ export default {
       }, '')
     },
     async uploadAudioData(data) {
-      // ここでの12桁の ID がファイル名になる
-      const audioRef = storageRef.child(this.createId())
+      // ここでの ID がポストID & ファイル名になる
+      const id = this.createId()
+      const audioRef = audioStorageRef.child(id)
       await audioRef.put(data).then(snapshot => {
         console.log(`added firebase storage: ${snapshot.state}!!`)
       })
       await audioRef.getDownloadURL().then(url => {
-        this.downloadAudioUrl = url
-        // Vuex に URL を追加する
-        this.addAudioUrl(this.downloadAudioUrl)
+        // store に ID と URL を追加する
+        this.addPostId(id)
+        this.addAudioUrl(url)
       })
     }
   }

--- a/store/post.js
+++ b/store/post.js
@@ -75,13 +75,18 @@ export const state = () => ({
     こののに破るねという吉利個性分りだのも自分ない。`
   },
   hoge: [],
-  audioUrl: 'http://www.voice-pro.jp/announce/mp3/001-sibutomo.mp3'
+  postData: {
+    id: null,
+    audioUrl: null
+  }
 })
 
 export const mutations = {
+  ADD_POST_ID(state, id) {
+    state.postData.id = id
+  },
   ADD_AUDIO_URL(state, url) {
-    console.log(url)
-    state.audioUrl = url
+    state.postData.audioUrl = url
   }
 }
 
@@ -89,6 +94,9 @@ export const actions = {
   initPosts: firestoreAction(({ bindFirestoreRef }) => {
     bindFirestoreRef('hoge', postsCollection)
   }),
+  addPostId({ commit }, id) {
+    commit('ADD_POST_ID', id)
+  },
   addAudioUrl({ commit }, url) {
     commit('ADD_AUDIO_URL', url)
   }

--- a/store/post.js
+++ b/store/post.js
@@ -75,7 +75,7 @@ export const state = () => ({
     こののに破るねという吉利個性分りだのも自分ない。`
   },
   hoge: [],
-  audioUrl: ''
+  audioUrl: 'http://www.voice-pro.jp/announce/mp3/001-sibutomo.mp3'
 })
 
 export const mutations = {


### PR DESCRIPTION
refs #81 

- 録音処理を終えて、vuex に情報を追加する
- 新規投稿ページにて、audio タグに vuex の URL 情報を読み込む（確認の再生）
- サムネイル画像のインプット処理
  - 画像データのアップロード（URL を取得）
- Editor.js のJSON データを取得
- Firebase へ投稿データをアップロード
 - 投稿ID、Auth情報、記事タイトル、サムネイルURL、オーディオURL、記事詳細、投稿日時

- ミドルウェア処理
  - 新規投稿ページにアクセスしたとき、Audio Data URL が Store になければ録音ページにリダイレクト