### PR TITLE
audioタグのタイトルを省略して表示

### DIFF
--- a/components/Organisms/AudioBar.vue
+++ b/components/Organisms/AudioBar.vue
@@ -279,7 +279,7 @@ export default {
   height: 10rem;
   background: $color-white;
   color: $dark-gray-text-color;
-  padding: 2rem 0.5rem;
+  padding: 1.5rem 0.5rem;
   width: 100vw;
   display: flex;
   flex-direction: column;
@@ -311,6 +311,9 @@ export default {
 .post__title {
   margin-left: 1rem;
   width: 70vw;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 
 .post_thumbnail__author_name {

--- a/components/Organisms/AudioBar.vue
+++ b/components/Organisms/AudioBar.vue
@@ -309,7 +309,7 @@ export default {
 }
 
 .post__title {
-  margin-left: 1rem;
+  margin-left: 0.7rem;
   width: 70vw;
   overflow: hidden;
   white-space: nowrap;
@@ -326,6 +326,7 @@ export default {
   background: $color-primary;
   width: 3rem;
   height: 3rem;
+  margin-top: 0.3rem;
   border-radius: 50%;
 }
 


### PR DESCRIPTION
refs #92 

- audioタグのタイトルの「・・・」での省略表示

- 見た目のバランス調整

<img width="227" alt="スクリーンショット 2019-10-01 15 38 29" src="https://user-images.githubusercontent.com/43144816/65940130-ae143a80-e462-11e9-8203-ba1830c8287b.png">

