### PR TITLE
Firebase から一覧ページのデータを取得して、ニュースフィード（一覧）に表示させる

### DIFF
--- a/components/Molecules/PostThumbnail.vue
+++ b/components/Molecules/PostThumbnail.vue
@@ -15,21 +15,11 @@
               @click="goToPrevious"
             />
           </div>
-
           <div class="post_thumbnail__header__container">
             <div class="post_thumbnail__header">
               <h1 class="post_thumbnail__header__title">
                 {{ post.title }}
               </h1>
-              <div class="post_thumbnail__header__tags">
-                <span
-                  v-for="(tag, tagIndex) in post.tags"
-                  :key="tagIndex"
-                  class="post_thumbnail__header__tag"
-                >
-                  #{{ tag }}
-                </span>
-              </div>
             </div>
             <div class="post_thumbnail__status">
               <div class="post_thumbnail__author">
@@ -43,12 +33,6 @@
                 </span>
                 <span class="post_thumbnail__posted_at">
                   {{ getPostedAt(post.posted_at) }}
-                </span>
-              </div>
-              <div class="post_thumbnail__like">
-                <heart-icon class="icon__heart" />
-                <span class="post_thumbnail__like_number">
-                  {{ post.like || '' }}
                 </span>
               </div>
             </div>

--- a/mixins/formatDateMixins.js
+++ b/mixins/formatDateMixins.js
@@ -1,9 +1,15 @@
 export default {
   methods: {
     getPostedAt(postedAt) {
-      const date = new Date(postedAt.replace(/-/g, '-'))
+
+      const date = Number((String(postedAt.seconds) + String(postedAt.nanoseconds)).substring(0, 13))
+      const minDiff = Math.floor((new Date() - date) / 60000)
       const timeDiff = Math.floor((new Date() - date) / 3600000)
       const dateDiff = Math.floor(timeDiff / 24)
+
+      if (timeDiff === 0) {
+        return `${minDiff} minutes ago`
+      }
 
       if (dateDiff === 0) {
         // 24 時間以内の更新の場合、時間を表示する

--- a/pages/posts/index.vue
+++ b/pages/posts/index.vue
@@ -5,7 +5,7 @@
         v-for="(post, key) in feedPosts"
         :key="key"
         class="news-feed-post"
-        @click="goToPostPage(key)"
+        @click="goToPostPage(post.id)"
       >
         <post-thumbnail :post="post" />
       </div>
@@ -25,7 +25,7 @@ export default {
   },
   computed: {
     ...mapState({
-      feedPosts: store => store.post.feedPosts
+      feedPosts: store => store.post.posts
     })
   },
   created() {
@@ -33,8 +33,8 @@ export default {
   },
   methods: {
     ...mapActions('post', ['initPosts']),
-    goToPostPage(key) {
-      this.$router.push({ path: `posts/${key}` })
+    goToPostPage(id) {
+      this.$router.push({ path: `posts/${id}` })
     }
   }
 }
@@ -43,6 +43,7 @@ export default {
 <style lang="scss" scoped>
 .news-feed-post__container {
   background: $color-white;
+  margin-bottom: 20rem;
 
   .news-feed-post {
     width: 100%;

--- a/pages/posts/new.vue
+++ b/pages/posts/new.vue
@@ -161,13 +161,12 @@ export default {
       db.collection('posts').doc(this.postId).set(requestPostData)
       .then(() => {
         console.log(`success!! post ID: ${this.postId}`)
+        // 今後マイポスト管理ページに遷移する
+        this.$router.push('/posts')
       })
       .catch(e => {
         console.error(e)
       })
-      
-      // 4, マイポストページにリダイレクトする
-        // this.$router.push('/my-page')
     },
     handleClick() {
       console.log('clicked!!')

--- a/store/post.js
+++ b/store/post.js
@@ -5,6 +5,7 @@ const db = firebase.firestore()
 const postsCollection = db.collection('posts')
 
 export const state = () => ({
+  // サンプルポストデータ
   feedPosts: [
     {
       id: 1,
@@ -74,7 +75,9 @@ export const state = () => ({
     これを力院を食ったふりのためをその供的のにしん。事実し来ごまぐれ当りへ一年松山縁を味をして、国爺さんから本位けもつれまし一方、静粛間柄を出来ませて、どう会員のお話も少なく、人など味から思って西洋に通じ世間と聴このがするなけれ、仕方少なくに二カ月も私をしなくです家士を理非け知れと、ここなり云って入っとなっないそうない。ただどんながたの無法とか党派心を香にという、もっの個人が受けので二杯の廃墟が個性に去っべきと起しで。三口はそんな珍を時分へ不愉快によかっ片仮名を解りば、それに目黒ほかならですて、事実の打ち壊さばもその間の力の釣から同時に先生が思わについてお話しに、もしその自信を許さ事を応じないのです。そうして十人のうちの一本を人格が譴責云って、国家のお話に行かので信じんず。
     こののに破るねという吉利個性分りだのも自分ない。`
   },
-  hoge: [],
+
+  // vuexfire でバインドするデータ一覧と投稿時に保持しておくデータ
+  posts: [],
   postData: {
     id: null,
     audioUrl: null
@@ -92,7 +95,7 @@ export const mutations = {
 
 export const actions = {
   initPosts: firestoreAction(({ bindFirestoreRef }) => {
-    bindFirestoreRef('hoge', postsCollection)
+    bindFirestoreRef('posts', postsCollection.orderBy('posted_at', 'desc'))
   }),
   addPostId({ commit }, id) {
     commit('ADD_POST_ID', id)


### PR DESCRIPTION
refs #89 

- `vuexFire` で取得しているポスト一覧データを `newsFeed (url: '/posts/index')` に表示させた

- 表示順を新着順にした `(orderBy('posted_at'))`

- `mixins` の `formatDateMixins.js` で、`N minutes ago` の処理と追記し表示させた


![Untitled](https://user-images.githubusercontent.com/45064837/65941168-56c39980-e465-11e9-938f-1816e7d8d7ed.gif)

