### PR TITLE
AudioBar コンポーネントの表示と非表示の切り替え

### DIFF
--- a/components/Organisms/AudioBar.vue
+++ b/components/Organisms/AudioBar.vue
@@ -17,23 +17,26 @@
         >
           <div class="traveler-icon__container">
             <img
-              :src="post.author.icon_url"
+              :src="audio.author.icon_url"
               class="traveler-icon"
             >
           </div>
           <div class="post__title">
-            {{ post.title }}
+            {{ audio.title }}
             <div class="post_thumbnail__author_name">
-              @{{ post.author.name }}
+              @{{ audio.author.name }}
             </div>
           </div>
         </div>
 
         <!-- play / pause アイコン （小）ここから-->
-        <div :class="classForPlayIcon">
+        <div
+          :class="classForPlayIcon"
+          class="icon_controls__container"
+        >
           <div
             v-if="!isPlaying"
-            class="audio_controller--play"
+            class="audio_controller --play"
             @click="playAudio()"
           >
             <div class="icon_contain_circle">
@@ -43,11 +46,15 @@
 
           <div
             v-else
+            class="audio_controller --pause"
             @click="pauseAudio()"
           >
             <div class="icon_contain_circle">
               <icon-pause class="icon_pause" />
             </div>
+          </div>
+          <div class="icon_close__container">
+            <span @click="closeAudioBar()">✕</span>
           </div>
         </div>
         <!-- play / pause アイコン （小）ここまで-->
@@ -129,7 +136,7 @@
 </template>
 
 <script>
-import { mapState } from 'vuex'
+import { mapState, mapActions } from 'vuex'
 import IconPlay from '~/components/Atoms/Icons/IconPlay'
 import IconPause from '~/components/Atoms/Icons/IconPause'
 import IconProceed from '~/components/Atoms/Icons/IconProceed'
@@ -170,25 +177,37 @@ export default {
     audioDuration: null, // audioトータル時間
     audioCurrentTime: null, // audio 経過時間
     timerObj: null,
-    audioData: 'http://www.voice-pro.jp/announce/mp3/001-sibutomo.mp3'
+    // audioData: 'http://www.voice-pro.jp/announce/mp3/001-sibutomo.mp3'
   }),
   computed: {
     ...mapState({
-      post: store => store.post.post
+      post: store => store.post.post,
+      audio: store => store.audio.audioData
     }),
     getParams() {
       return this.$route.params.id
     }
   },
   async mounted() {
-    const audio = new Audio(this.audioData)
+    // audio data を template の audio タグ と紐付ける
+    const audio = new Audio(this.audio.audio_url)
     this.$refs.audio = audio
+    console.log(this.$refs)
     await audio.load()
     audio.onloadedmetadata = () => {
       this.audioDuration = audio.duration
     }
+
+    // store に audio 情報があったら playAudio() を発火
+    if(this.audio) {
+      this.playAudio()
+    }
+  },
+  beforeDestroy() {
+    this.pauseAudio()
   },
   methods: {
+    ...mapActions('audio',['resetAudioData']),
     changeAudioFooterSize() {
       if (this.className === 'audio--open') {
         this.className = 'audio--close'
@@ -260,6 +279,9 @@ export default {
       this.className = 'audio--close'
       this.classForPlayIcon = 'showed'
       this.classForAudioDetail = 'hidden'
+    },
+    closeAudioBar() {
+      this.resetAudioData()
     }
   }
 }
@@ -318,7 +340,17 @@ export default {
 
 .post_thumbnail__author_name {
   font-size: 1.2rem;
-  line-height: 1rem;
+  line-height: 1.4rem;
+}
+
+.icon_controls__container {
+  position: relative;
+}
+
+.audio_controller {
+  position: absolute;
+  top: .5rem;
+  right: 4rem;
 }
 
 .icon_contain_circle {
@@ -339,6 +371,13 @@ export default {
 
 .icon_pause {
   margin-top: -0.9rem;
+}
+
+.icon_close__container {
+  position: absolute;
+  top: .8rem;
+  right: 0rem;
+  font-size: 2rem;
 }
 
 .audio--open {

--- a/layouts/user.vue
+++ b/layouts/user.vue
@@ -11,7 +11,10 @@
       >
         <!-- <icon-record /> 宙に浮いた録音アイコン。念の為残してます-->
       </div>
-      <audio-bar class="post_audio" />
+      <audio-bar
+        v-if="isAudioData"
+        class="post_audio"
+      />
       <app-footer
         class="app_footer"
         :path="getPath"
@@ -47,6 +50,7 @@
 </template>
 
 <script>
+import { mapState } from 'vuex'
 import AppHeader from '~/components/Molecules/AppHeader'
 import AppAsideMenu from '~/components/Organisms/AppAsideMenu'
 import AppFooter from '~/components/Molecules/AppFooter'
@@ -63,8 +67,17 @@ export default {
     // IconRecord
   },
   computed: {
+    ...mapState({
+      audioData: store => store.audio.audioData
+    }),
     getPath() {
       return this.$route.path
+    },
+    isAudioData() {
+      if (this.audioData) {
+        return true
+      }
+      return false
     }
   },
   methods: {

--- a/pages/posts/_id/index.vue
+++ b/pages/posts/_id/index.vue
@@ -6,8 +6,19 @@
           :post="post"
           class="post__thumbnail"
         />
-        <div class="post-audio__container">
-          <audio :src="post.audio_url" controls/>
+        <div class="episode-play__container">
+          <div
+            class="icon-play__container"
+            @click="audioPlay"
+          >
+            <icon-play class="icon-play"/>
+          </div>
+          <p
+            class="episode-play__text"
+            @click="audioPlay"
+          >
+            Play Episode
+          </p>
         </div>
         <div
           v-for="(doc , index) in post.article"
@@ -23,8 +34,9 @@
 
 <script>
 import { db } from '~/plugins/firebase'
-import { mapState } from 'vuex'
+import { mapState, mapActions } from 'vuex'
 import PostThumbnail from '~/components/Molecules/PostThumbnail'
+import IconPlay from '~/components/Atoms/Icons/IconPlay'
 
 const postsCollection = db.collection('posts')
 
@@ -32,7 +44,8 @@ export default {
   name: 'Post',
   layout: 'user',
   components: {
-    PostThumbnail
+    PostThumbnail,
+    IconPlay
   },
   async asyncData({ params }) {
       return await postsCollection.doc(params.id).get()
@@ -44,6 +57,38 @@ export default {
             post: data
           }
         })
+  },
+  computed: {
+    ...mapState({
+      audio: store => store.audio.audioData
+    }),
+  },
+  methods: {
+    ...mapActions('audio',['setAudioData', 'resetAudioData']),
+    async audioPlay() {
+      await this.setAudio()
+    },
+    async setAudio() {
+      const data = {
+        author: {
+          name: this.post.author.name,
+          icon_url: this.post.author.icon_url,
+        },
+        title: this.post.title,
+        audio_url: this.post.audio_url
+      }
+
+      if (this.audio) {
+        await this.resetAudio()
+        this.setAudioData(data)
+        return
+      }
+
+      this.setAudioData(data)
+    },
+    resetAudio() {
+      this.resetAudioData()
+    }
   }
 }
 </script>
@@ -51,6 +96,7 @@ export default {
 <style lang="scss" scoped>
 .post__container {
   background-color: $color-white;
+  margin-bottom: 12rem;
 }
 
 .post__thumbnail /deep/ {
@@ -104,6 +150,37 @@ export default {
 .post-audio__container {
   text-align: center;
   padding: 3rem 0;
+}
+
+
+// 仮再生ボタン
+.episode-play__container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 3rem;
+}
+
+.icon-play__container {
+  position: relative;
+  width: 4rem;
+  height: 4rem;
+  background-color: $button-gray;
+  border-radius: 50%;
+  margin-right: 1.4rem;
+}
+
+.icon-play {
+  position: absolute;
+  width: 2rem;
+  fill: #fff;
+  left: 30%;
+}
+
+.episode-play__text {
+  font-size: 2rem;
+  font-weight: bold;
+  margin-bottom: 0
 }
 
 </style>

--- a/store/audio.js
+++ b/store/audio.js
@@ -1,0 +1,27 @@
+// This store for AudioBar information
+
+export const state = () => ({
+  audioData: null
+})
+
+export const getters = {
+  audioData: state => state.audioData
+}
+
+export const mutations = {
+  SET_AUDIO_DATA(state, data) {
+    state.audioData = data
+  },
+  RESET_AUDIO_DATA(state) {
+    state.audioData = null
+  }
+}
+
+export const actions = {
+  setAudioData({ commit }, data) {
+    commit('SET_AUDIO_DATA', data)
+  },
+  resetAudioData({ commit }) {
+    commit('RESET_AUDIO_DATA')
+  }
+}


### PR DESCRIPTION
refs #112 

- store に再生の情報をもたせる `audio.js` を作成
- ポストページの Play Episode をクリックしたら、音声の情報を `audio.js` に追加
- `audio.js` を元に表示非表示を切り替える
  - 存在すれば表示、存在しなければ非表示
- AudioBar のsmall 状態のときに `✕`（close icon） を追加
  - `✕` をクリックしたら、`audio.js` の情報を リセット => AudioBar は消える

このあと `✕` をIcon Component 化する
ポストページの  `Play Episode` のUIも変更すべきか…


![Untitled](https://user-images.githubusercontent.com/45064837/66226237-505b4900-e715-11e9-9f26-22bfc11cce4c.gif)
