### PR TITLE
自分のポストした投稿をマイポストページに表示する

### DIFF
--- a/components/Molecules/AppFooter.vue
+++ b/components/Molecules/AppFooter.vue
@@ -38,17 +38,14 @@ export default {
     buttonLinks: [
       {
         icon: 'balloon',
-        link: 'posts',
         path: '/posts'
       },
       {
         icon: 'record',
-        link: 'recording',
         path: '/recording'
       },
       {
         icon: 'star',
-        link: 'favorite',
         path: '/favorite'
       }
     ]
@@ -58,7 +55,7 @@ export default {
       return 'icon-' + buttonLink.icon
     },
     iconClasses(buttonLink) {
-      if (this.path.includes(buttonLink.link)) {
+      if (this.path === buttonLink.path) {
         return { is_path: true }
       }
       return {}

--- a/components/Molecules/PostThumbnail.vue
+++ b/components/Molecules/PostThumbnail.vue
@@ -58,7 +58,10 @@ export default {
   computed: {
     isPostPage() {
       const path = this.$route.path
-      if (path === '/posts') {
+      if (
+        path === '/posts' ||
+        path === '/my-posts'
+      ) {
         return false
       }
       return true

--- a/pages/my-posts.vue
+++ b/pages/my-posts.vue
@@ -2,20 +2,16 @@
   <div class="my-posts__wrapper">
     <div class="my-posts__user_container">
       <img
-        :src="user.icon_url"
+        :src="auth.photoURL"
         class="my-posts__user_icon"
         alt="icon_url"
       >
       <div class="my-posts__user_account">
         <p class="my-posts__user_name">
-          @{{ user.name }}
-        </p>
-        <p class="my-posts__user_place">
-          {{ user.place }}
+          @{{ auth.displayName }}
         </p>
       </div>
     </div>
-
     <div class="post-category_container">
       <div class="post-category selected">
         投稿済み
@@ -26,15 +22,17 @@
         <div class="bottom-border hidden" />
       </div>
     </div>
-
     <div class="my-posts__container">
       <div
-        v-for="(post, key) in feedPosts"
-        :key="key"
+        v-for="(post, index) in feedPosts"
+        :key="index"
         class="my-posts"
-        @click="goToPostPage(key)"
+        @click="goToPostPage(post.id)"
       >
-        <post-thumbnail :post="post" />
+        <post-thumbnail
+          v-if="isAuthorId(post.author.uid)"
+          :post="post"
+        />
       </div>
     </div>
   </div>
@@ -52,8 +50,8 @@ export default {
   },
   computed: {
     ...mapState({
-      user: store => store.user.user,
-      feedPosts: store => store.post.feedPosts,
+      auth: store => store.auth.user,
+      feedPosts: store => store.post.posts,
     })
   },
   created() {
@@ -61,6 +59,13 @@ export default {
   },
   methods: {
     ...mapActions('post', ['initPosts']),
+    isAuthorId(uid) {
+      if (uid === this.auth.uid) {
+        return true
+      } else {
+        return false
+      }
+    },
     goToPostPage(key) {
       this.$router.push({ path: `posts/${key}` })
     }


### PR DESCRIPTION
refs #114 

- ポストページのアイコンと名前をログイン者のものに変更
- 自分の UID と 投稿データの投稿者 UID を見て、一致したらポストページにサムネイルを表示
- フッターの選択カラーが、マイポストページにも反映していたので修正

<img width="300" alt="スクリーンショット 2019-10-06 2 26 10" src="https://user-images.githubusercontent.com/45064837/66258475-b19c1e80-e7e0-11e9-84de-e55d73d5b193.png">
