### PR TITLE
サインアップ / ログインの処理の再設定とページ遷移の見直し

### DIFF
--- a/components/Molecules/AppFooter.vue
+++ b/components/Molecules/AppFooter.vue
@@ -38,7 +38,7 @@ export default {
     buttonLinks: [
       {
         icon: 'balloon',
-        path: '/posts'
+        path: '/'
       },
       {
         icon: 'record',

--- a/components/Molecules/PostThumbnail.vue
+++ b/components/Molecules/PostThumbnail.vue
@@ -60,7 +60,6 @@ export default {
       const path = this.$route.path
       if (
         path === '/' ||
-        path === '/posts' ||
         path === '/my-posts'
       ) {
         return false
@@ -70,7 +69,7 @@ export default {
   },
   methods: {
     goToPrevious() {
-      this.$router.push('/posts')
+      this.$router.push('/')
     }
   }
 }

--- a/components/Molecules/PostThumbnail.vue
+++ b/components/Molecules/PostThumbnail.vue
@@ -59,6 +59,7 @@ export default {
     isPostPage() {
       const path = this.$route.path
       if (
+        path === '/' ||
         path === '/posts' ||
         path === '/my-posts'
       ) {

--- a/components/Organisms/AppAsideMenu.vue
+++ b/components/Organisms/AppAsideMenu.vue
@@ -69,7 +69,7 @@ export default {
         {
           icon: 'news-feed',
           label: 'ニュースフィード',
-          path: '/posts'
+          path: '/'
         },
         {
           icon: 'search',
@@ -79,7 +79,7 @@ export default {
         {
           icon: 'my-page',
           label: 'マイページ',
-          path: '/posts'
+          path: '/'
         },
         {
           icon: 'follow',
@@ -104,12 +104,12 @@ export default {
         {
           icon: 'category',
           label: 'カテゴリ',
-          path: '/posts'
+          path: '/'
         },
         {
           icon: 'tag',
           label: 'タグ',
-          path: '/posts'
+          path: '/'
         }
       ]
   }),

--- a/middleware/authenticated.js
+++ b/middleware/authenticated.js
@@ -25,7 +25,6 @@ export default async ({ route, store, redirect }) => {
     store.state.auth.user ||
     isGeneralPage(route.path)
   ) {
-    console.log('一般ページ')
     return
   }
 

--- a/middleware/authenticated.js
+++ b/middleware/authenticated.js
@@ -17,6 +17,10 @@ export default async ({ route, store, redirect }) => {
     return
   }
 
+  if (route.path === '/posts') {
+    return redirect('/')
+  }
+
   await firebase.auth().onAuthStateChanged(user => {
     // ログインしていたら、store に追加する
     if (user) {

--- a/middleware/authenticated.js
+++ b/middleware/authenticated.js
@@ -2,18 +2,30 @@ import firebase from '~/plugins/firebase'
 
 firebase.auth().setPersistence(firebase.auth.Auth.Persistence.LOCAL)
 
+// 一般閲覧可能なページのパスリスト
+const pathList = [
+  '/',
+  '/search',
+  '/login',
+  '/signup',
+  '/register-name'
+]
+
+// 一般ページかどうかチェックする関数
+const isGeneralPage = path => {
+  return pathList.some(_path => {
+    return path === _path
+  })
+}
+
 export default async ({ route, store, redirect }) => {
   
   // store にログイン情報があるとき
-  // 一般閲覧可能なページのときは、何もしない
   if (
     store.state.auth.user ||
-    route.path === '/' ||
-    route.path === '/search' ||
-    route.path === '/login' ||
-    route.path === '/signup' ||
-    route.path === '/signup_name'
+    isGeneralPage(route.path)
   ) {
+    console.log('一般ページ')
     return
   }
 

--- a/middleware/authenticated.js
+++ b/middleware/authenticated.js
@@ -8,7 +8,7 @@ export default async ({ route, store, redirect }) => {
   // 一般閲覧可能なページのときは、何もしない
   if (
     store.state.auth.user ||
-    route.path === '/news_feed' ||
+    route.path === '/' ||
     route.path === '/search' ||
     route.path === '/login' ||
     route.path === '/signup' ||

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -112,7 +112,8 @@ export default {
     PROJECTID,
     STORAGEBUCKET,
     MESSAGINGSENDERID,
-    APPID
+    APPID,
+    baseUrl: process.env.BASE_URL || 'https://stayonair.jp/'
   },
   router: {
     middleware: ['authenticated']

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,77 +1,67 @@
 <template>
-  <div class="signin__container">
-    <form
-      class="form__container"
-      @submit.prevent="sendForm"
-    >
-      <form-input
-        v-model="formData.email"
-        name="form-input"
-        inner-label="Email"
-      />
-      <app-button
-        color="white"
-        text="CONTINUE"
-      />
-    </form>
-    <nuxt-link to="record">録音</nuxt-link>
+  <div class="news-feed-post__wrapper">
+    <div class="news-feed-post__container">
+      <div
+        v-for="(post, key) in feedPosts"
+        :key="key"
+        class="news-feed-post"
+        @click="goToPostPage(post.id)"
+      >
+        <post-thumbnail :post="post" />
+      </div>
+    </div>
   </div>
 </template>
 
 <script>
-import FormInput from '~/components/Molecules/FormInput.vue'
-import AppButton from '~/components/Atoms/AppButton.vue'
+import { mapState, mapActions } from 'vuex'
+import PostThumbnail from '~/components/Molecules/PostThumbnail'
 
 export default {
+  name: 'NewsFeed',
+  layout: 'user',
   components: {
-    FormInput,
-    AppButton
+    PostThumbnail
   },
-  data: () => {
-    return {
-      formData: {
-        email: ''
-      }
-    }
+  computed: {
+    ...mapState({
+      feedPosts: store => store.post.posts
+    })
+  },
+  created() {
+    this.initPosts()
   },
   methods: {
-    sendForm() {
-      console.log(this.formData)
+    ...mapActions('post', ['initPosts']),
+    goToPostPage(id) {
+      this.$router.push({ path: `posts/${id}` })
     }
   }
 }
 </script>
 
-<style lang="scss">
-.form__container {
-  margin: 0 auto;
-  min-height: 100vh;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  text-align: center;
-  background: $background-black;
-}
+<style lang="scss" scoped>
+.news-feed-post__container {
+  background: $color-white;
+  margin-bottom: 20rem;
 
-.title {
-  font-family: 'Quicksand', 'Source Sans Pro', -apple-system, BlinkMacSystemFont,
-    'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
-  display: block;
-  font-weight: 300;
-  font-size: 100px;
-  color: #35495e;
-  letter-spacing: 1px;
-}
+  .news-feed-post {
+    width: 100%;
+    height: auto;
+    max-width: 50rem;
+    max-height: 30rem;
+    margin: 0 auto;
+    box-shadow: inset 0 0 0 25rem rgba(0, 30, 40, 0.6);
+    transition: all 0.4s;
 
-.subtitle {
-  font-weight: 300;
-  font-size: 42px;
-  color: #526488;
-  word-spacing: 5px;
-  padding-bottom: 15px;
-}
+    &:not(:last-child) {
+      margin-bottom: 4rem;
+    }
 
-.links {
-  padding-top: 15px;
+    &:hover {
+      opacity: 0.8;
+      transform: scale(0.99, 0.99);
+    }
+  }
 }
 </style>

--- a/pages/login.vue
+++ b/pages/login.vue
@@ -83,20 +83,20 @@ export default {
   methods: {
     login() {
       auth.signInWithEmailAndPassword(this.email, this.password).then(() => {
-        this.$router.push('/news_feed')
+        this.$router.push('/')
         console.log(auth.currentUser)
       })
     },
     facebookLogin() {
       const facebook = new firebase.auth.FacebookAuthProvider()
       auth.signInWithPopup(facebook).then(() => {
-        this.$router.push('/news_feed')
+        this.$router.push('/')
       })
     },
     twitterLogin() {
       const twitter = new firebase.auth.TwitterAuthProvider()
       auth.signInWithPopup(twitter).then(() => {
-        this.$router.push('/news_feed')
+        this.$router.push('/')
       })
     }
   }

--- a/pages/login.vue
+++ b/pages/login.vue
@@ -84,7 +84,6 @@ export default {
     login() {
       auth.signInWithEmailAndPassword(this.email, this.password).then(() => {
         this.$router.push('/')
-        console.log(auth.currentUser)
       })
     },
     facebookLogin() {

--- a/pages/posts/new.vue
+++ b/pages/posts/new.vue
@@ -162,7 +162,7 @@ export default {
       .then(() => {
         console.log(`success!! post ID: ${this.postId}`)
         // 今後マイポスト管理ページに遷移する
-        this.$router.push('/posts')
+        this.$router.push('/my-posts')
       })
       .catch(e => {
         console.error(e)

--- a/pages/register-name.vue
+++ b/pages/register-name.vue
@@ -56,8 +56,8 @@ export default {
           // photoURL: ''
         })
         .then(() => {
-          console.log('Update successful')
-          this.$router.push('/posts')
+          console.log('Profile update successful')
+          this.$router.push('/')
         })
         .catch(e => {
           console.error(e)

--- a/pages/signup.vue
+++ b/pages/signup.vue
@@ -117,10 +117,11 @@ export default {
               .sendEmailVerification({
                 // リダイレクト先のURL
                 // 動作確認のため localhost
-                url: 'http://localhost:3000/register-name'
+                url: 'https://stayonair.jp/register-name/'
               })
               .then(() => {
                 console.log('Successfully sent email')
+                // メールを送信したことがわかるページに遷移する
               })
           }
         })
@@ -131,13 +132,13 @@ export default {
     facebookLogin() {
       const facebook = new firebase.auth.FacebookAuthProvider()
       auth.signInWithPopup(facebook).then(() => {
-        this.$router.push('/posts/')
+        this.$router.push('/register-name')
       })
     },
     twitterLogin() {
       const twitter = new firebase.auth.TwitterAuthProvider()
       auth.signInWithPopup(twitter).then(() => {
-        this.$router.push('/posts')
+        this.$router.push('/register-name')
       })
     }
   }

--- a/pages/signup.vue
+++ b/pages/signup.vue
@@ -93,8 +93,6 @@ export default {
   }),
   methods: {
     async signup() {
-      console.log(`${this.baseUrl}register-name/`)
-      return
       // 入力したパスワードと確認パスワードが一致していない時
       if (this.password !== this.confirmPassword) {
         console.log('パスワードが一致していません')

--- a/pages/signup.vue
+++ b/pages/signup.vue
@@ -83,6 +83,9 @@ export default {
     AppButton,
     IconBalloon
   },
+  asyncData: context => ({
+    baseUrl: context.env.baseUrl
+  }),
   data: () => ({
     email: '',
     password: '',
@@ -90,6 +93,8 @@ export default {
   }),
   methods: {
     async signup() {
+      console.log(`${this.baseUrl}register-name/`)
+      return
       // 入力したパスワードと確認パスワードが一致していない時
       if (this.password !== this.confirmPassword) {
         console.log('パスワードが一致していません')
@@ -117,7 +122,7 @@ export default {
               .sendEmailVerification({
                 // リダイレクト先のURL
                 // 動作確認のため localhost
-                url: 'https://stayonair.jp/register-name/'
+                url: `${this.baseUrl}register-name/`
               })
               .then(() => {
                 console.log('Successfully sent email')


### PR DESCRIPTION
refs #119 
- index ページを ニュースフィードにした
- SNS サインアップ後、ネーム登録画面に遷移しユーザーネームを変更できるようにした
  - ログインとの違いは、ネーム登録できるかどうか
- それに伴っての、各処理後のルーティングの再設定

**レビュー後**
- .env でBASE_URL を追加した
  - ローカル開発において、.env（BASE_URL） があるときは、localhost にアクセスする

- ミドルウェア( authenticated.js )のページ遷移に、一般閲覧ページをチェックする関数を追加した
- 不要なコメントメッセージを削除した