### PR TITLE
サインアップ時に Firebase にユーザーコレクションを作成する

### DIFF
--- a/pages/register-name.vue
+++ b/pages/register-name.vue
@@ -48,9 +48,6 @@ export default {
   data: () => ({
     userName: ''
   }),
-  created() {
-    console.log(auth.currentUser.uid)
-  },
   methods: {
     async createUser() {
       if (!this.userName) {
@@ -61,7 +58,7 @@ export default {
         bookmarks: [],
         introduction: ''
       })
-      
+
       auth.currentUser.updateProfile({
           displayName: this.userName
           // photoURL: ''

--- a/pages/register-name.vue
+++ b/pages/register-name.vue
@@ -7,7 +7,7 @@
     <div class="create_name__container">
       <form
         class="form__container"
-        @submit.prevent="createName()"
+        @submit.prevent="createUser()"
       >
         <input
           v-model="userName"
@@ -37,7 +37,8 @@
 import IconBalloon from '~/components/Atoms/Icons/IconBalloon'
 import AppButton from '~/components/Atoms/AppButton'
 
-import firebase from '~/plugins/firebase'
+import { db, auth } from '~/plugins/firebase'
+const usersCollection = db.collection('users')
 
 export default {
   components: {
@@ -47,11 +48,21 @@ export default {
   data: () => ({
     userName: ''
   }),
+  created() {
+    console.log(auth.currentUser.uid)
+  },
   methods: {
-    async createName() {
-      await firebase
-        .auth()
-        .currentUser.updateProfile({
+    async createUser() {
+      if (!this.userName) {
+        return
+      }
+
+      await usersCollection.doc(auth.currentUser.uid).set({
+        bookmarks: [],
+        introduction: ''
+      })
+      
+      auth.currentUser.updateProfile({
           displayName: this.userName
           // photoURL: ''
         })

--- a/pages/signup.vue
+++ b/pages/signup.vue
@@ -23,13 +23,13 @@
         color="transparent"
         text="SIGNUP WITH FACEBOOK"
         icon="fab fa-facebook-f"
-        @click="facebookLogin()"
+        @click="snsLogin('facebook')"
       />
       <app-button
         color="transparent"
         text="SIGNUP WITH TWITTER"
         icon="fab fa-twitter"
-        @click="twitterLogin()"
+        @click="snsLogin(twitter)"
       />
     </div>
 
@@ -132,16 +132,33 @@ export default {
           console.error(e)
         })
     },
-    facebookLogin() {
-      const facebook = new firebase.auth.FacebookAuthProvider()
-      auth.signInWithPopup(facebook).then(() => {
-        this.$router.push('/register-name')
-      })
-    },
-    twitterLogin() {
-      const twitter = new firebase.auth.TwitterAuthProvider()
-      auth.signInWithPopup(twitter).then(() => {
-        this.$router.push('/register-name')
+    snsLogin(sns) {
+      let provider = ''
+      switch (sns) {
+        case 'facebook':
+          provider = new firebase.auth.FacebookAuthProvider()
+          break
+        case 'twitter':
+          provider = new firebase.auth.TwitterAuthProvider()
+          break
+      }
+
+      auth.signInWithPopup(provider).then(auth => {
+        usersCollection.get().then(snapshot => {
+          const existUser = snapshot.docs.some(doc => {
+            return auth.user.uid === doc.id
+          })
+
+          // コレクションに情報があったら、index
+          if (existUser) {
+            this.$router.push('/')
+            return
+          }
+          
+          // なければ、サインアップの処理
+          this.$router.push('/register-name')
+
+        })
       })
     }
   }

--- a/pages/signup.vue
+++ b/pages/signup.vue
@@ -29,7 +29,7 @@
         color="transparent"
         text="SIGNUP WITH TWITTER"
         icon="fab fa-twitter"
-        @click="snsLogin(twitter)"
+        @click="snsLogin('twitter')"
       />
     </div>
 


### PR DESCRIPTION
refs #170 

#### SNSでのサインアップ / ログイン時に、Firebase の `users` コレクションに、自分の `UID` があるか確認する。
- ある場合はログインの処理を行う
- ない場合は、サインアップを行っていないので、ネイム登録画面（`register-name.vue`）に遷移させ、その時に`users` コレクションに `UID` を追加する。

#### `signup.vue` & `login.vue`にて
Firebase のSNS ログイン（サインアップも）処理をまとめた。